### PR TITLE
Python interface with ctypes

### DIFF
--- a/LISAinference/LISAutils.c
+++ b/LISAinference/LISAutils.c
@@ -149,6 +149,19 @@ void InitGlobalParams(void)
   globalparams->frozenLISA = 0;
   globalparams->responseapprox = full;
   globalparams->tagsimplelikelihood = 0;
+
+  injectedparams = (LISAParams *)malloc(sizeof(LISAParams));
+  memset(injectedparams, 0, sizeof(LISAParams));
+  injectedparams->tRef = 0.;
+  injectedparams->phiRef = 0.;
+  injectedparams->m1 = 2*1e6;
+  injectedparams->m2 = 1*1e6;
+  injectedparams->distance = 40*1e3;
+  injectedparams->lambda = 0.;
+  injectedparams->beta = 0.;
+  injectedparams->inclination = PI/3.;
+  injectedparams->polarization = 0.;
+  injectedparams->nbmode = globalparams->nbmodeinj;
 }
 
 /* Parse command line to initialize LISAParams, LISAPrior, and LISARunParams objects */

--- a/LISAinference/LISAutils.c
+++ b/LISAinference/LISAutils.c
@@ -128,6 +128,8 @@ void LISAInjectionReIm_Init(LISAInjectionReIm** signal) {
 
 /************ Parsing arguments function ************/
 
+/* This function must be called by Python scripts as soon as possible
+   to make sure global variables are set up with meaningful values */
 void InitGlobalParams(void)
 {
   globalparams = (LISAGlobalParams *)malloc(sizeof(LISAGlobalParams));

--- a/LISAinference/LISAutils.c
+++ b/LISAinference/LISAutils.c
@@ -128,6 +128,29 @@ void LISAInjectionReIm_Init(LISAInjectionReIm** signal) {
 
 /************ Parsing arguments function ************/
 
+void InitGlobalParams(void)
+{
+  globalparams = (LISAGlobalParams *)malloc(sizeof(LISAGlobalParams));
+  memset(globalparams, 0, sizeof(LISAGlobalParams));
+  globalparams->fRef = 0.;
+  globalparams->deltatobs = 2.;
+  globalparams->minf = 0.;
+  globalparams->maxf = 1.;
+  globalparams->tagextpn = 1;
+  globalparams->tagtRefatLISA = 0;
+  globalparams->Mfmatch = 0.;
+  globalparams->nbmodeinj = 5;
+  globalparams->nbmodetemp = 5;
+  globalparams->tagint = 0;
+  globalparams->tagtdi = TDIAETXYZ;
+  globalparams->nbptsoverlap = 32768;
+  globalparams->variant = &LISAProposal;
+  globalparams->zerolikelihood = 0;
+  globalparams->frozenLISA = 0;
+  globalparams->responseapprox = full;
+  globalparams->tagsimplelikelihood = 0;
+}
+
 /* Parse command line to initialize LISAParams, LISAPrior, and LISARunParams objects */
 void parse_args_LISA(ssize_t argc, char **argv,
   LISAParams* params,
@@ -1170,6 +1193,7 @@ int LISAGenerateInjectionReIm(
 
   /* Starting frequency corresponding to duration of observation deltatobs */
   double fstartobs = 0.;
+  printf("%p\n", injectedparams);
   if(!(globalparams->deltatobs==0.)) fstartobs = Newtonianfoft(params->m1, params->m2, globalparams->deltatobs);
 
   /* Generate the waveform with the ROM */

--- a/LISAinference/LISAutils.c
+++ b/LISAinference/LISAutils.c
@@ -1208,7 +1208,6 @@ int LISAGenerateInjectionReIm(
 
   /* Starting frequency corresponding to duration of observation deltatobs */
   double fstartobs = 0.;
-  printf("%p\n", injectedparams);
   if(!(globalparams->deltatobs==0.)) fstartobs = Newtonianfoft(params->m1, params->m2, globalparams->deltatobs);
 
   /* Generate the waveform with the ROM */
@@ -1460,6 +1459,198 @@ double CalculateLogLReIm(LISAParams *params, LISAInjectionReIm* injection)
   LISASignalReIm_Cleanup(generatedsignal);
 
   return logL;
+}
+
+double CalculateOverlapReIm(LISAParams params1, LISAParams params2, LISAInjectionReIm * injection)
+{
+  double overlap = -DBL_MAX;
+  int ret;
+
+  /* Frequency vector - assumes common to A,E,T, i.e. identical fLow, fHigh in all channels */
+  gsl_vector* freq = injection->freq;
+
+  /* Generating the signal in the three detectors for the input parameters */
+  LISASignalReIm* signal1 = NULL;
+  LISASignalReIm* signal2 = NULL;
+  LISASignalReIm_Init(&signal1);
+  LISASignalReIm_Init(&signal2);
+  ret = LISAGenerateSignalReIm(&params1, freq, signal1);
+  if(ret==SUCCESS){
+    ret = LISAGenerateSignalReIm(&params2, freq, signal2);
+  }
+  /* If LISAGenerateSignal failed (e.g. parameters out of bound), silently return -Infinity logL */
+  if(ret==FAILURE) {
+    overlap = -DBL_MAX;
+  }
+  else if(ret==SUCCESS) {
+    /* Computing the likelihood for each TDI channel - fstartobs has already been taken into account */
+    double loglikelihoodTDI1 = FDLogLikelihoodReIm(signal1->TDI1Signal, signal2->TDI1Signal, injection->noisevalues1);
+    double loglikelihoodTDI2 = FDLogLikelihoodReIm(signal1->TDI2Signal, signal2->TDI2Signal, injection->noisevalues2);
+    double loglikelihoodTDI3 = FDLogLikelihoodReIm(signal1->TDI3Signal, signal2->TDI3Signal, injection->noisevalues3);
+    overlap = loglikelihoodTDI1 + loglikelihoodTDI2 + loglikelihoodTDI3;
+  }
+
+  /* Clean up */
+  LISASignalReIm_Cleanup(signal1);
+  LISASignalReIm_Cleanup(signal2);
+
+  //cout<<" overlap="<<overlap<<endl;
+  return overlap;
+}
+
+double CalculateOverlapCAmpPhase(LISAParams params1, LISAParams params2, LISAInjectionCAmpPhase * injection)
+{
+  double overlap = -DBL_MAX;
+  int ret;
+  bool resampling=true;
+  double overlap_grid_rescale=128.0,grid_frac=0.98;
+  bool grid_rescale_top=true;
+  
+  /* Generating the signal in the three detectors for the input parameters */
+  LISASignalCAmpPhase* signal1 = NULL;
+  LISASignalCAmpPhase_Init(&signal1);
+  //Note that the code for CAmpPhase overlaps is asymmetric, with one signal called the injection in the form of precomputed splines...
+  LISAInjectionCAmpPhase* signal2 = NULL;
+  LISAInjectionCAmpPhase_Init(&signal2);
+
+  ret = LISAGenerateSignalCAmpPhase(&params1, signal1);
+  if(ret==SUCCESS){
+    ret = LISAGenerateInjectionCAmpPhase(&params2, signal2);
+  }
+
+  if(resampling){
+    //For each mode we resample the signal1 grid to align with the nominal "injection" freq domain
+    //optionally rescaling the frequency grid (approximately) by factor overlap_grid_rescale.
+    //Note that the overlap uses signal1 to define the grid, so this realizes a change in the overlap sampling
+
+    //First we prepare splines to use later for interpolation
+    
+    ListmodesCAmpPhaseSpline* listsplinesgen1 = NULL;
+    ListmodesCAmpPhaseSpline* listsplinesgen2 = NULL;
+    ListmodesCAmpPhaseSpline* listsplinesgen3 = NULL;
+    BuildListmodesCAmpPhaseSpline(&listsplinesgen1, signal1->TDI1Signal);
+    BuildListmodesCAmpPhaseSpline(&listsplinesgen2, signal1->TDI2Signal);
+    BuildListmodesCAmpPhaseSpline(&listsplinesgen3, signal1->TDI3Signal);
+
+    //loop over modes
+    ListmodesCAmpPhaseFrequencySeries* mode = signal1->TDI1Signal;
+    int nsize=-1;//Seem this must be the same number for all modes//set first time through loop.
+    while(mode) {
+//cout<<"l= "<<mode->l<<"  m="<<mode->m<<"  nsize="<<nsize<<endl;
+ListmodesCAmpPhaseSpline* centermode=ListmodesCAmpPhaseSpline_GetMode(injection->TDI1Splines,mode->l,mode->m);
+gsl_vector_view ofreq_vv=gsl_matrix_column(centermode->splines->quadspline_phase,0);
+gsl_vector* ofreq = &ofreq_vv.vector;
+double s1f0=gsl_vector_get(mode->freqseries->freq,0);
+double s1fend=gsl_vector_get(mode->freqseries->freq,mode->freqseries->freq->size-1);
+double f0=gsl_vector_get(ofreq,0);
+int osize=ofreq->size,i0=0;
+double fend=gsl_vector_get(ofreq,osize-1);
+if(f0<s1f0){//s1 does not extend down as far as nominal freq range; trim range
+  f0=s1f0;
+  while(gsl_vector_get(ofreq,i0)<f0 && i0<osize-1)i0++;//select old-grid index to immediate left of f0
+}
+//cout<<"start: i0="<<i0<<" n,o sizes = "<<nsize<<", "<<osize<<endl;
+if(fend>s1fend){//s1 does not extend up as far as nominal freq range; trim range
+  fend=s1fend;
+  while(gsl_vector_get(ofreq,osize-1)>fend && i0<osize-1)osize--;//select old-grid index to immediate right of fend
+  //{cout<<"i0="<<i0<<" < "<<osize<<" f = "<<gsl_vector_get(ofreq,osize-1)<<" > "<<fend<<endl;osize--;}
+}
+if(nsize<0){
+  if(grid_rescale_top)
+    nsize=(overlap_grid_rescale*(1.0-grid_frac)+grid_frac)*(osize-i0);//Only set the first time (expected to be 22)
+  else
+    nsize=(1+(overlap_grid_rescale-1)*grid_frac)*(osize-i0);//Only set the first time (expected to be 22)
+}
+//cout<<"end: i0="<<i0<<" n,o sizes = "<<nsize<<", "<<osize<<endl;
+gsl_vector* nfreq = gsl_vector_alloc(nsize);
+double f=f0;
+gsl_vector_set(nfreq,0,f);//first point
+for(int i=1;i<nsize-1;i++){
+  while(gsl_vector_get(ofreq,i0)<f && i0<osize-2)i0++;//select old-grid index to left of f
+  //cout<<"i="<<i<<" i0="<<i0<<" n,o sizes = "<<nsize<<", "<<osize<<endl;
+  double odelta=gsl_vector_get(ofreq,i0+1)-gsl_vector_get(ofreq,i0);
+  double ofremain=gsl_vector_get(ofreq,osize-1)-gsl_vector_get(ofreq,i0);
+  double nfremain=fend-f;
+  double ndelta=odelta*nfremain/ofremain*(double)(osize-i0)/(double)(nsize-i);//rescale df by ratio of old/new mean df of remaining domain.
+  if(i0+1<(int)(osize*grid_frac)){
+    int effosize=osize*grid_frac,effnsize;
+    if(grid_rescale_top)effnsize=nsize/(overlap_grid_rescale*(1.0/grid_frac-1.0)+1.0);
+    else effnsize=nsize*grid_frac*overlap_grid_rescale/((overlap_grid_rescale-1.0)*grid_frac+1.0);
+    //cout<<"effosize="<<effosize<<"  effnsize="<<effnsize<<endl;
+    if(effnsize<1)effnsize=1; //just in case
+    ofremain=gsl_vector_get(ofreq,effosize-1)-gsl_vector_get(ofreq,i0);
+    nfremain=gsl_vector_get(ofreq,effosize-1)-f;
+    ndelta=odelta*nfremain/ofremain*(double)(effosize-i0)/(double)(effnsize-i);//rescale df by ratio of old/new mean df of remaining domain.
+  }
+  //cout<<"  ofreq(i0)="<<gsl_vector_get(ofreq,i0)<<" odelta="<<odelta<<" ofremain="<<ofremain<<endl;;
+  //cout<<"   f,ndelta "<<f<<","<<ndelta<<" fend="<<fend<<endl;
+  f+=ndelta;
+  gsl_vector_set(nfreq,i,f);
+}
+gsl_vector_set(nfreq,nsize-1,fend);//last point
+
+//Also need to work with TDI2 and TDI3
+ListmodesCAmpPhaseFrequencySeries* mode2 = ListmodesCAmpPhaseFrequencySeries_GetMode(signal1->TDI2Signal,mode->l,mode->m);
+ListmodesCAmpPhaseFrequencySeries* mode3 = ListmodesCAmpPhaseFrequencySeries_GetMode(signal1->TDI3Signal,mode->l,mode->m);
+CAmpPhaseSpline * splines1 = ListmodesCAmpPhaseSpline_GetMode(listsplinesgen1,mode->l,mode->m)->splines;
+CAmpPhaseSpline * splines2 = ListmodesCAmpPhaseSpline_GetMode(listsplinesgen2,mode->l,mode->m)->splines;
+CAmpPhaseSpline * splines3 = ListmodesCAmpPhaseSpline_GetMode(listsplinesgen3,mode->l,mode->m)->splines;
+  
+//resize allocated memory
+//CAmpPhaseFrequencySeries_Cleanup(mode->freqseries);
+//mode->freqseries=new CAmpPhaseFrequencySeries;
+CAmpPhaseFrequencySeries_Init(&mode->freqseries,nsize);
+//CAmpPhaseFrequencySeries_Cleanup(mode2->freqseries);
+CAmpPhaseFrequencySeries_Init(&mode2->freqseries,nsize);
+//CAmpPhaseFrequencySeries_Cleanup(mode3->freqseries);
+CAmpPhaseFrequencySeries_Init(&mode3->freqseries,nsize);
+
+//fill new values
+gsl_vector_memcpy(mode->freqseries->freq,nfreq);
+gsl_vector_memcpy(mode2->freqseries->freq,nfreq);
+gsl_vector_memcpy(mode3->freqseries->freq,nfreq);
+
+EvalCAmpPhaseSpline(splines1,mode->freqseries);
+EvalCAmpPhaseSpline(splines2,mode2->freqseries);
+EvalCAmpPhaseSpline(splines3,mode3->freqseries);
+
+//clean up
+gsl_vector_free(nfreq);
+
+mode=mode->next;
+    }//end loop over modes
+    
+    //clean up
+    ListmodesCAmpPhaseSpline_Destroy(listsplinesgen1);
+    ListmodesCAmpPhaseSpline_Destroy(listsplinesgen2);
+    ListmodesCAmpPhaseSpline_Destroy(listsplinesgen3);
+
+  }//end resampling
+
+  /* If LISAGenerateSignal failed (e.g. parameters out of bound), silently return -Infinity logL */
+  if(ret==FAILURE) {
+    overlap = -DBL_MAX;
+  }
+  else if(ret==SUCCESS) {
+    /* Computing the likelihood for each TDI channel - fstartobs is the max between the fstartobs of the injected and generated signals */
+    double fstartobs1 = Newtonianfoft(params1.m1, params1.m2, globalparams->deltatobs);
+    double fstartobs2 = Newtonianfoft(params2.m1, params2.m2, globalparams->deltatobs);
+    double fLow = fmax(__LISASimFD_Noise_fLow, globalparams->minf);
+    double fHigh = fmin(__LISASimFD_Noise_fHigh, globalparams->maxf);
+    ObjectFunction NoiseSn1 = NoiseFunction(globalparams->variant, globalparams->tagtdi, 1);
+    ObjectFunction NoiseSn2 = NoiseFunction(globalparams->variant, globalparams->tagtdi, 2);
+    ObjectFunction NoiseSn3 = NoiseFunction(globalparams->variant, globalparams->tagtdi, 3);
+    
+    overlap = FDListmodesFresnelOverlap3Chan(signal1->TDI1Signal, signal1->TDI2Signal, signal1->TDI3Signal, signal2->TDI1Splines, signal2->TDI2Splines, signal2->TDI3Splines, &NoiseSn1, &NoiseSn2, &NoiseSn3, fLow, fHigh, fstartobs2, fstartobs1);
+    
+  }
+
+  /* Clean up */
+  LISASignalCAmpPhase_Cleanup(signal1);
+  LISAInjectionCAmpPhase_Cleanup(signal2);
+  
+  //cout<<" overlap="<<overlap<<endl;
+  return overlap;
 }
 
 /****************** Functions precomputing relevant values when using simplified likelihood *****************/

--- a/libflare/Makefile
+++ b/libflare/Makefile
@@ -1,0 +1,60 @@
+# Makefile for building a shared library that can be used from Python via ctypes
+
+all: libflare.so.1.0.0
+
+COMPILE=gcc -c -O3 -fPIC -o $@ -I../tools -I../EOBNRv2HMROM -I../integration \
+		-I../LISAsim
+
+OBJECTS=LISAutils.o LISAgeometry.o LISAFDresponse.o LISAnoise.o struct.o \
+		waveform.o fresnel.o EOBNRv2HMROM.o EOBNRv2HMROMstruct.o \
+		splinecoeffs.o likelihood.o wip.o Faddeeva.o spline.o
+
+LISAutils.o: ../LISAinference/LISAutils.c
+	$(COMPILE) ../LISAinference/LISAutils.c
+
+LISAgeometry.o: ../LISAsim/LISAgeometry.c
+	$(COMPILE) ../LISAsim/LISAgeometry.c
+
+LISAFDresponse.o: ../LISAsim/LISAFDresponse.c
+	$(COMPILE) ../LISAsim/LISAFDresponse.c
+
+LISAnoise.o: ../LISAsim/LISAnoise.c
+	$(COMPILE) ../LISAsim/LISAnoise.c
+
+EOBNRv2HMROM.o: ../EOBNRv2HMROM/EOBNRv2HMROM.c
+	$(COMPILE) ../EOBNRv2HMROM/EOBNRv2HMROM.c
+
+EOBNRv2HMROMstruct.o: ../EOBNRv2HMROM/EOBNRv2HMROMstruct.c
+	$(COMPILE) ../EOBNRv2HMROM/EOBNRv2HMROMstruct.c
+
+struct.o: ../tools/struct.c
+	$(COMPILE) ../tools/struct.c
+
+waveform.o: ../tools/waveform.c
+	$(COMPILE) ../tools/waveform.c
+
+splinecoeffs.o: ../tools/splinecoeffs.c
+	$(COMPILE) ../tools/splinecoeffs.c
+
+likelihood.o: ../tools/likelihood.c
+	$(COMPILE) ../tools/likelihood.c
+
+fresnel.o: ../tools/fresnel.c
+	$(COMPILE) ../tools/fresnel.c
+
+wip.o: ../integration/wip.c
+	$(COMPILE) ../integration/wip.c
+
+Faddeeva.o: ../integration/Faddeeva.c
+	$(COMPILE) ../integration/Faddeeva.c
+
+spline.o: ../integration/spline.c
+	$(COMPILE) ../integration/spline.c
+
+libflare.so.1.0.0: $(OBJECTS)
+	gcc -shared -fPIC \
+		-Wl,-soname,libflare.so.1,--unresolved-symbols=report-all \
+        -lgsl -lgslcblas -lm -lc -o $@ $(OBJECTS)
+
+clean:
+	rm -f *.o libflare.so.1.0.0

--- a/libflare/examples/flare.py
+++ b/libflare/examples/flare.py
@@ -1,0 +1,70 @@
+"""Python interface to FLARE."""
+
+import numpy as np
+from ctypes import cdll, Structure, c_double, c_int, c_void_p, byref
+
+
+class LISAParams(Structure):
+    _fields_ = [('tRef', c_double),
+                ('phiRef', c_double),
+                ('m1', c_double),
+                ('m2', c_double),
+                ('distance', c_double),
+                ('lambda_', c_double),
+                ('beta', c_double),
+                ('inclination', c_double),
+                ('polarization', c_double),
+                ('nbmode', c_int)]
+
+    def __init__(self, p=None):
+        if type(p) is dict:
+            self.m1 = p['mass1']
+            self.m2 = p['mass2']
+            self.distance = p['distance']
+            self.lambda_ = p['lambda']
+            self.beta = p['beta']
+            self.inclination = p['inclination']
+            self.polarization = p['polarization']
+            self.nbmode = p['n_modes']
+
+
+lib = cdll.LoadLibrary("libflare.so.1.0.0")
+
+# tell ctypes the return types for the functions we'll use
+lib.CalculateLogLReIm.restype = c_double
+lib.CalculateOverlapReIm.restype = c_double
+
+# must initialize flare's global internal variables first
+lib.InitGlobalParams()
+
+def generate_injection_reim(**kwa):
+    """Generate a simulated signal in LISA.
+    """
+    # initialize a LISAInjectionReIm struct
+    injection = c_void_p(None)
+    lib.LISAInjectionReIm_Init(byref(injection))
+
+    params = LISAParams(kwa)
+
+    # realize an injected signal into the LISAInjectionReIm struct
+    lib.LISAGenerateInjectionReIm(byref(params), c_double(kwa['f_low']),
+                                  c_int(kwa['n_samples']),
+                                  c_int(kwa['log_samples']), injection)
+
+    return injection
+
+def calculate_logl_reim(**kwa):
+    """Calculate the log-likelihood given an injection and the parameters of a
+    template.
+    """
+    params = LISAParams(kwa)
+
+    return lib.CalculateLogLReIm(byref(params), kwa['injection'])
+
+def calculate_overlap_reim(params1, params2, injection):
+    """Calculate the overlap between signals of different parameter vectors.
+    """
+    p1 = LISAParams(params1)
+    p2 = LISAParams(params2)
+
+    return lib.CalculateOverlapReIm(p1, p2, injection)

--- a/libflare/examples/test_likelihood.py
+++ b/libflare/examples/test_likelihood.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pylab as pl
+import flare
+
+
+inj_params = dict(mass1=2e6, mass2=1e6, distance=10e3,
+                  beta=-0.073604, inclination=0.6459, polarization=1.7436,
+                  n_modes=5, f_low=1e-3, n_samples=32768, log_samples=True)
+inj_params['lambda'] = 3.4435 # doh
+injection = flare.generate_injection_reim(**inj_params)
+
+# calculate the log-likelihood for a bunch
+# of random masses around the injected masses
+m1s_ = np.random.normal(inj_params['mass1'], 50, 100)
+m2s_ = np.random.normal(inj_params['mass2'], 50, 100)
+m1s = np.where(m1s_ > m2s_, m1s_, m2s_)
+m2s = np.where(m1s_ > m2s_, m2s_, m1s_)
+lls = []
+for m1, m2 in zip(m1s, m2s):
+    template_params = inj_params.copy()
+    template_params['mass1'] = m1
+    template_params['mass2'] = m2
+    template_params['injection'] = injection
+    lls.append(flare.calculate_logl_reim(**template_params))
+
+# plot the likelihood
+lls = np.array(lls)
+sorter = np.argsort(lls)
+pl.tricontourf(m1s[sorter], m2s[sorter], np.exp(lls[sorter]), 100, cmap='gnuplot2_r')
+pl.colorbar()
+pl.axvline(inj_params['mass1'], color='#00ff00')
+pl.axhline(inj_params['mass2'], color='#00ff00')
+pl.xlabel('Mass 1')
+pl.ylabel('Mass 2')
+pl.show()

--- a/libflare/examples/test_overlap.py
+++ b/libflare/examples/test_overlap.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pylab as pl
+import flare
+
+
+inj_params = dict(mass1=2e6, mass2=1e6, distance=10e3,
+                  beta=-0.073604, inclination=0.6459, polarization=1.7436,
+                  n_modes=5, f_low=1e-3, n_samples=32768, log_samples=True)
+inj_params['lambda'] = 3.4435 # doh
+injection = flare.generate_injection_reim(**inj_params)
+
+# calculate the log-likelihood for a bunch
+# of random masses around the injected masses
+m1s_ = np.random.normal(inj_params['mass1'], 50, 1000)
+m2s_ = np.random.normal(inj_params['mass2'], 50, 1000)
+m1s = np.where(m1s_ > m2s_, m1s_, m2s_)
+m2s = np.where(m1s_ > m2s_, m2s_, m1s_)
+o = []
+for m1, m2 in zip(m1s, m2s):
+    template_params = inj_params.copy()
+    template_params['mass1'] = m1
+    template_params['mass2'] = m2
+    o.append(flare.calculate_overlap_reim(inj_params, template_params, injection))
+
+# plot the overlap
+o = np.array(o)
+sorter = np.argsort(o)
+pl.scatter(m1s[sorter], m2s[sorter], c=o[sorter], cmap='gnuplot2_r')
+pl.colorbar()
+pl.axvline(inj_params['mass1'], color='#00ff00')
+pl.axhline(inj_params['mass2'], color='#00ff00')
+pl.xlabel('Mass 1')
+pl.ylabel('Mass 2')
+pl.show()


### PR DESCRIPTION
Adds a little Makefile for building a shared library and a couple Python examples to show how it can be used to calculate likelihoods and overlaps.

Note that I copied a couple of overlap functions from LISAinference_ptmcmc.cc to LISAutils.c, so they can be called in this way. We should remove them from LISAinference_ptmcmc.cc in the future.